### PR TITLE
Owen dev

### DIFF
--- a/Source/CineScope/Client/Pages/UserProfile/ProfileManagement.razor
+++ b/Source/CineScope/Client/Pages/UserProfile/ProfileManagement.razor
@@ -2,8 +2,10 @@
 @using CineScope.Shared.DTOs
 @using CineScope.Client.Shared.Profile
 @using CineScope.Shared.Auth;
+@using CineScope.Client.Services.Auth;
 @using System.Net.Http.Json
 @inject HttpClient Http
+@inject AuthService AuthService
 @inject ISnackbar Snackbar
 @attribute [Authorize]
 
@@ -358,6 +360,9 @@
 
             if (response.IsSuccessStatusCode)
             {
+                // Refresh auth state to update navbar
+                await AuthService.RefreshUserStateAsync();
+
                 Snackbar.Add("Profile picture updated", Severity.Success);
                 profilePictureUpdated = false;
             }
@@ -447,6 +452,9 @@
 
             if (response.IsSuccessStatusCode)
             {
+                // Refresh the authentication state to update the navbar
+                await AuthService.RefreshUserStateAsync();
+
                 Snackbar.Add("Profile updated successfully", Severity.Success);
                 isEditing = false;
                 errorMessage = string.Empty;

--- a/Source/CineScope/Client/Pages/UserProfile/ProfileManagement.razor
+++ b/Source/CineScope/Client/Pages/UserProfile/ProfileManagement.razor
@@ -355,13 +355,13 @@
                     ProfilePictureUrl = user.ProfilePictureUrl
                 };
 
-            // Call API to update just the profile picture
+            // Call API to update the profile picture
             var response = await Http.PutAsJsonAsync("api/User/profile-picture", updateRequest);
 
             if (response.IsSuccessStatusCode)
             {
-                // Refresh auth state to update navbar
-                await AuthService.RefreshUserStateAsync();
+                // Use the RefreshUserProfile method which is already correctly implemented
+                await AuthService.RefreshUserProfile();
 
                 Snackbar.Add("Profile picture updated", Severity.Success);
                 profilePictureUpdated = false;

--- a/Source/CineScope/Client/Shared/Auth/AuthenticationLayout.razor
+++ b/Source/CineScope/Client/Shared/Auth/AuthenticationLayout.razor
@@ -1,6 +1,7 @@
 ﻿@using CineScope.Client.Services
 @using CineScope.Client.Services.Auth
 @using CineScope.Shared.DTOs
+@using CineScope.Client.Shared.Profile
 @inherits LayoutComponentBase
 @inject AuthService AuthService
 @inject ISnackbar Snackbar
@@ -21,21 +22,19 @@
 
             <AuthorizeView>
                 <Authorized>
+                    <!-- Show profile picture and user menu -->
                     <MudMenu AnchorOrigin="Origin.BottomCenter" TransformOrigin="Origin.TopCenter">
                         <ActivatorContent>
-                            <MudAvatar Style="height: 40px; width: 40px; cursor: pointer;">
-                                @if (!string.IsNullOrEmpty(context.User.FindFirst("ProfilePictureUrl")?.Value))
-                                {
-                                    <img src="@context.User.FindFirst("ProfilePictureUrl")?.Value" alt="Profile" />
-                                }
-                                else
-                                {
-                                    <MudIcon Icon="@Icons.Material.Filled.AccountCircle" />
-                                }
-                            </MudAvatar>
+                            <div style="cursor: pointer;">
+                                <ProfilePictureDisplay Url="@GetProfilePictureUrl(context)"
+                                                       Username="@context.User.Identity.Name"
+                                                       Size="Size.Medium"
+                                                       Width="40"
+                                                       Height="40" />
+                            </div>
                         </ActivatorContent>
                         <ChildContent>
-                            <MudText Typo="Typo.body2" Class="px-4 py-2">@context.User.Identity?.Name</MudText>
+                            <MudText Typo="Typo.body2" Class="px-4 py-2">@context.User.Identity.Name</MudText>
                             <MudDivider Class="mb-2" />
                             <MudMenuItem OnClick="@(() => NavigationManager.NavigateTo("/profile"))">My Profile</MudMenuItem>
                             <MudMenuItem OnClick="@(() => NavigationManager.NavigateTo("/my-reviews"))">My Reviews</MudMenuItem>
@@ -44,7 +43,7 @@
                     </MudMenu>
                 </Authorized>
                 <NotAuthorized>
-                    <!-- Show these items when user is not authenticated -->
+                    <!-- Login/register buttons -->
                     <MudButton Variant="Variant.Text" Color="Color.Inherit" OnClick="@(() => NavigationManager.NavigateTo("/login"))">Login</MudButton>
                     <MudButton Variant="Variant.Outlined" Color="Color.Inherit" OnClick="@(() => NavigationManager.NavigateTo("/register"))">Register</MudButton>
                 </NotAuthorized>
@@ -120,5 +119,45 @@
         await AuthService.Logout();
         Snackbar.Add("You have been logged out", Severity.Success);
         NavigationManager.NavigateTo("/");
+    }
+
+    /// <summary>
+    /// Gets the user's profile picture URL from the authentication context.
+    /// </summary>
+    private string GetProfilePictureUrl(AuthenticationState context)
+    {
+        try
+        {
+            // Debug: list all claims
+            foreach (var claim in context.User.Claims)
+            {
+                Console.WriteLine($"Claim: {claim.Type} = {claim.Value}");
+            }
+
+            // Check for ProfilePictureUrl claim
+            var profilePictureClaim = context.User.FindFirst("ProfilePictureUrl");
+
+            if (profilePictureClaim != null && !string.IsNullOrWhiteSpace(profilePictureClaim.Value))
+            {
+                Console.WriteLine($"Found profile picture URL: {profilePictureClaim.Value}");
+                return profilePictureClaim.Value;
+            }
+
+            // If user is authenticated but no profile picture claim found,
+            // use avatar8.svg since we know it exists
+            if (context.User.Identity.IsAuthenticated)
+            {
+                Console.WriteLine("User authenticated but no profile picture claim found, using avatar8.svg");
+                return "/profile-pictures/avatar8.svg";
+            }
+
+            // Default fallback
+            return "/profile-pictures/default.svg";
+        }
+        catch (Exception ex)
+        {
+            Console.WriteLine($"Error getting profile picture: {ex.Message}");
+            return "/profile-pictures/default.svg";
+        }
     }
 }

--- a/Source/CineScope/Client/Shared/Auth/AuthenticationLayout.razor
+++ b/Source/CineScope/Client/Shared/Auth/AuthenticationLayout.razor
@@ -21,13 +21,26 @@
 
             <AuthorizeView>
                 <Authorized>
-                    <!-- Show these items when user is authenticated -->
-                    <MudMenu Icon="@Icons.Material.Filled.AccountCircle" Color="Color.Inherit" AnchorOrigin="Origin.BottomCenter" TransformOrigin="Origin.TopCenter">
-                        <MudText Typo="Typo.body2" Class="px-4 py-2">@context.User.Identity.Name</MudText>
-                        <MudDivider Class="mb-2" />
-                        <MudMenuItem OnClick="@(() => NavigationManager.NavigateTo("/profile"))">My Profile</MudMenuItem>
-                        <MudMenuItem OnClick="@(() => NavigationManager.NavigateTo("/my-reviews"))">My Reviews</MudMenuItem>
-                        <MudMenuItem OnClick="Logout">Logout</MudMenuItem>
+                    <MudMenu AnchorOrigin="Origin.BottomCenter" TransformOrigin="Origin.TopCenter">
+                        <ActivatorContent>
+                            <MudAvatar Style="height: 40px; width: 40px; cursor: pointer;">
+                                @if (!string.IsNullOrEmpty(context.User.FindFirst("ProfilePictureUrl")?.Value))
+                                {
+                                    <img src="@context.User.FindFirst("ProfilePictureUrl")?.Value" alt="Profile" />
+                                }
+                                else
+                                {
+                                    <MudIcon Icon="@Icons.Material.Filled.AccountCircle" />
+                                }
+                            </MudAvatar>
+                        </ActivatorContent>
+                        <ChildContent>
+                            <MudText Typo="Typo.body2" Class="px-4 py-2">@context.User.Identity?.Name</MudText>
+                            <MudDivider Class="mb-2" />
+                            <MudMenuItem OnClick="@(() => NavigationManager.NavigateTo("/profile"))">My Profile</MudMenuItem>
+                            <MudMenuItem OnClick="@(() => NavigationManager.NavigateTo("/my-reviews"))">My Reviews</MudMenuItem>
+                            <MudMenuItem OnClick="Logout">Logout</MudMenuItem>
+                        </ChildContent>
                     </MudMenu>
                 </Authorized>
                 <NotAuthorized>

--- a/Source/CineScope/Client/Shared/Profile/ProfilePictureDisplay.razor
+++ b/Source/CineScope/Client/Shared/Profile/ProfilePictureDisplay.razor
@@ -23,7 +23,10 @@
         // If URL is null or empty, use the default profile picture
         if (string.IsNullOrEmpty(Url))
         {
-            Url = ProfilePictureOptions.DefaultProfilePicture;
+            // Make sure this path matches the actual path structure you're using
+            Url = "/profile-pictures/default.svg";
         }
+
+        Console.WriteLine($"ProfilePictureDisplay initialized with URL: {Url}");
     }
 }

--- a/Source/CineScope/Client/Shared/Profile/ProfilePictureOptions.cs
+++ b/Source/CineScope/Client/Shared/Profile/ProfilePictureOptions.cs
@@ -9,7 +9,7 @@
         /// Base URL for profile pictures, either hosted on GitHub via jsDelivr or local to the application.
         /// For GitHub hosting, replace with your repository details.
         /// </summary>
-        private const string BaseUrl = "/images/profile-pictures/";
+        private const string BaseUrl = "/profile-pictures/";
 
         /// <summary>
         /// Gets the URLs to all available SVG profile pictures.

--- a/Source/CineScope/Client/Shared/Profile/UpdateProfileRequest.cs
+++ b/Source/CineScope/Client/Shared/Profile/UpdateProfileRequest.cs
@@ -1,4 +1,4 @@
-﻿namespace CineScope.Shared.Auth
+﻿namespace CineScope.Client.Shared.Profile
 {
     /// <summary>
     /// Represents a profile update request.

--- a/Source/CineScope/Server/Controllers/UserController.cs
+++ b/Source/CineScope/Server/Controllers/UserController.cs
@@ -9,7 +9,7 @@ using CineScope.Shared.DTOs;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 using MongoDB.Driver;
-using CineScope.Shared.Auth;
+using CineScope.Client.Shared.Profile;
 
 namespace CineScope.Server.Controllers
 {

--- a/Source/CineScope/Server/Services/AuthService.cs
+++ b/Source/CineScope/Server/Services/AuthService.cs
@@ -251,15 +251,26 @@ namespace CineScope.Server.Services
             var key = new SymmetricSecurityKey(Encoding.UTF8.GetBytes(jwtSecret));
             var creds = new SigningCredentials(key, SecurityAlgorithms.HmacSha256);
 
+            // Ensure we have a valid profile picture URL
+            string profilePictureUrl = !string.IsNullOrEmpty(user.ProfilePictureUrl)
+                ? user.ProfilePictureUrl
+                : "/profile-pictures/default.svg";
+
+            // Ensure path starts with /
+            if (!profilePictureUrl.StartsWith("/") && !profilePictureUrl.StartsWith("http"))
+            {
+                profilePictureUrl = "/" + profilePictureUrl;
+            }
+
             // Create claims for the token
             var claims = new List<Claim>
-{
-    new Claim(JwtRegisteredClaimNames.Sub, user.Id),
-    new Claim(JwtRegisteredClaimNames.UniqueName, user.Username),
-    new Claim(JwtRegisteredClaimNames.Email, user.Email),
-    new Claim("ProfilePictureUrl", user.ProfilePictureUrl ?? ""), 
-    new Claim(JwtRegisteredClaimNames.Jti, Guid.NewGuid().ToString())
-};
+    {
+        new Claim(JwtRegisteredClaimNames.Sub, user.Id),
+        new Claim(JwtRegisteredClaimNames.UniqueName, user.Username),
+        new Claim(JwtRegisteredClaimNames.Email, user.Email),
+        new Claim("ProfilePictureUrl", profilePictureUrl), // Make sure this claim has the exact name "ProfilePictureUrl"
+        new Claim(JwtRegisteredClaimNames.Jti, Guid.NewGuid().ToString())
+    };
 
             // Add role claims
             foreach (var role in user.Roles)

--- a/Source/CineScope/Server/Services/AuthService.cs
+++ b/Source/CineScope/Server/Services/AuthService.cs
@@ -149,6 +149,7 @@ namespace CineScope.Server.Services
                 Id = user.Id,
                 Username = user.Username,
                 Email = user.Email,
+                ProfilePictureUrl = user.ProfilePictureUrl, 
                 Roles = user.Roles
             };
 
@@ -219,6 +220,7 @@ namespace CineScope.Server.Services
                 Id = newUser.Id,
                 Username = newUser.Username,
                 Email = newUser.Email,
+                ProfilePictureUrl = newUser.ProfilePictureUrl, 
                 Roles = newUser.Roles
             };
 
@@ -251,12 +253,13 @@ namespace CineScope.Server.Services
 
             // Create claims for the token
             var claims = new List<Claim>
-            {
-                new Claim(JwtRegisteredClaimNames.Sub, user.Id),
-                new Claim(JwtRegisteredClaimNames.UniqueName, user.Username),
-                new Claim(JwtRegisteredClaimNames.Email, user.Email),
-                new Claim(JwtRegisteredClaimNames.Jti, Guid.NewGuid().ToString())
-            };
+{
+    new Claim(JwtRegisteredClaimNames.Sub, user.Id),
+    new Claim(JwtRegisteredClaimNames.UniqueName, user.Username),
+    new Claim(JwtRegisteredClaimNames.Email, user.Email),
+    new Claim("ProfilePictureUrl", user.ProfilePictureUrl ?? ""), 
+    new Claim(JwtRegisteredClaimNames.Jti, Guid.NewGuid().ToString())
+};
 
             // Add role claims
             foreach (var role in user.Roles)

--- a/Source/CineScope/Server/Services/UserService.cs
+++ b/Source/CineScope/Server/Services/UserService.cs
@@ -4,9 +4,9 @@ using CineScope.Server.Data;
 using CineScope.Server.Interfaces;
 using CineScope.Server.Models;
 using CineScope.Shared.DTOs;
-using CineScope.Shared.Auth; // Added this import to use the shared UpdateProfileRequest
 using Microsoft.Extensions.Options;
 using MongoDB.Driver;
+using CineScope.Client.Shared.Profile;
 
 namespace CineScope.Server.Services
 {


### PR DESCRIPTION
This pull request includes several changes to improve user profile management, specifically focusing on updating and refreshing user profile information and authentication states. The most important changes include adding new methods to refresh user profiles and authentication states, updating the UI to display profile pictures, and making necessary adjustments to the backend to support these features.

### User Profile Management Enhancements:

* [`Source/CineScope/Client/Pages/UserProfile/ProfileManagement.razor`](diffhunk://#diff-023d44e714f0d11417c72281a1c15c90dc02a6081be0c3d94740f85a89f8db30R5-R8): Injected `AuthService` and used the `RefreshUserProfile` method to update the profile picture and refresh the authentication state after a profile update. [[1]](diffhunk://#diff-023d44e714f0d11417c72281a1c15c90dc02a6081be0c3d94740f85a89f8db30R5-R8) [[2]](diffhunk://#diff-023d44e714f0d11417c72281a1c15c90dc02a6081be0c3d94740f85a89f8db30L356-R365) [[3]](diffhunk://#diff-023d44e714f0d11417c72281a1c15c90dc02a6081be0c3d94740f85a89f8db30R455-R457)

### Authentication Service Improvements:

* [`Source/CineScope/Client/Services/Auth/AuthService.cs`](diffhunk://#diff-84a2ac2aa467c2023ce421a15f0c1d1b3cc1be84858124645abefc82ef8938a5R320-R446): Added `RefreshUserStateAsync` and `RefreshUserProfile` methods to handle refreshing the authentication token and updating user profile information without requiring a full login.

### UI Updates for Profile Picture:

* [`Source/CineScope/Client/Shared/Auth/AuthenticationLayout.razor`](diffhunk://#diff-92005af75a27da769dde9b634d59b5529bfa2ac314af6b652d91823357607e4bL24-R46): Updated the layout to display the user's profile picture in the navigation bar and added a method to retrieve the profile picture URL from the authentication context. [[1]](diffhunk://#diff-92005af75a27da769dde9b634d59b5529bfa2ac314af6b652d91823357607e4bL24-R46) [[2]](diffhunk://#diff-92005af75a27da769dde9b634d59b5529bfa2ac314af6b652d91823357607e4bR123-R162)
* [`Source/CineScope/Client/Shared/Profile/ProfilePictureDisplay.razor`](diffhunk://#diff-8c2cadd2b3dc09ab4bb917c1c7791eb8943e44219a9470113298b6318710f54eL26-R30): Adjusted the default profile picture URL and added logging for initialization.

### Backend Support for Token Refresh:

* [`Source/CineScope/Server/Controllers/AuthController.cs`](diffhunk://#diff-721a07ac12be358900bc6221c10cab93f3b3801608638256c84d7698e6b1d036R135-R146): Added support for refreshing the authentication token and returning updated user information, including the profile picture URL. [[1]](diffhunk://#diff-721a07ac12be358900bc6221c10cab93f3b3801608638256c84d7698e6b1d036R135-R146) [[2]](diffhunk://#diff-721a07ac12be358900bc6221c10cab93f3b3801608638256c84d7698e6b1d036L151-L187)

These changes collectively enhance the user experience by ensuring that profile updates are reflected promptly in the UI and the authentication state, providing a more seamless and consistent experience for the user.